### PR TITLE
Manually called Thread.interrupt() to re-interrupt the current thread. 

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/io/file/exporter/KmzTrackExporter.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/exporter/KmzTrackExporter.java
@@ -83,6 +83,7 @@ public class KmzTrackExporter implements TrackExporter {
             return true;
         } catch (InterruptedException | IOException e) {
             Log.e(TAG, "Unable to write track", e);
+            Thread.currentThread().interrupt();
             return false;
         }
     }


### PR DESCRIPTION
Calling Thread.interrupt() ensures that the thread will be interrupted when InterruptedException is caught and will not risk delaying the thread shutdown or lose the information that the thread was interrupted.

Code Changes:

![image](https://github.com/rilling/OpenTracks-Winter-SOEN-6431_2024/assets/41756221/aa502709-65c7-4301-bf2d-995eb87b144f)
