### PR TITLE
Fix: Group9 issues: #1 #2 #6 #9 #11 #13 #14 #15

### DIFF
--- a/.idea/migrations.xml
+++ b/.idea/migrations.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectMigrations">
+    <option name="MigrateToGradleLocalJavaHome">
+      <set>
+        <option value="$PROJECT_DIR$" />
+      </set>
+    </option>
+  </component>
+</project>

--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:8.2.1'
+        classpath "org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:2.7.1"
     }
 }
 
@@ -145,4 +146,22 @@ dependencies {
     androidTestImplementation 'org.mockito:mockito-android:5.8.0'
 
     androidTestUtil 'androidx.test:orchestrator:1.4.2'
+}
+
+apply plugin: "org.sonarqube"
+
+sonarqube {
+    properties {
+        property "sonar.projectName", "OpenTracksConcordia"
+        property "sonar.projectKey", "OpenTracksConcordia"
+        property "sonar.tests", ["src/androidTest/java"]
+        property "sonar.test.inclusions", "/Test/"
+        property "sonar.sourceEncoding", "UTF-8"
+        property "sonar.sources", "src/main/java"
+        property "sonar.exclusions", '/Test/,' +
+                '.json,' +
+                '/test/,' +
+                '/.gradle/*,' +
+                '**/R.class'
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -6,8 +6,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.2.1'
-        classpath "org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:2.7.1"
+        classpath 'com.android.tools.build:gradle:8.2.2'
     }
 }
 
@@ -146,22 +145,4 @@ dependencies {
     androidTestImplementation 'org.mockito:mockito-android:5.8.0'
 
     androidTestUtil 'androidx.test:orchestrator:1.4.2'
-}
-
-apply plugin: "org.sonarqube"
-
-sonarqube {
-    properties {
-        property "sonar.projectName", "OpenTracksConcordia"
-        property "sonar.projectKey", "OpenTracksConcordia"
-        property "sonar.tests", ["src/androidTest/java"]
-        property "sonar.test.inclusions", "/Test/"
-        property "sonar.sourceEncoding", "UTF-8"
-        property "sonar.sources", "src/main/java"
-        property "sonar.exclusions", '/Test/,' +
-                '.json,' +
-                '/test/,' +
-                '/.gradle/*,' +
-                '**/R.class'
-    }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,5 @@
 android.useAndroidX=true
 org.gradle.jvmargs=-Xmx1024m
 
+systemProp.sonar.host.url=http://localhost:9000/
+systemProp.sonar.login=squ_4a8298fce62e10c463f5b14aef009aa7c7a5af37

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,4 @@
 android.useAndroidX=true
 org.gradle.jvmargs=-Xmx1024m
+systemProp.sonar.host.url=http://localhost:9000/
+systemProp.sonar.login=sqb_47114836a8cbd9b4bdc382c22d669fd2b0a8dd94

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,4 @@
 android.useAndroidX=true
 org.gradle.jvmargs=-Xmx1024m
+systemProp.sonar.host.url=http://localhost:9000/
+systemProp.sonar.login= sqp_2c42e4be92847c53bf4281979d4fa1d5d8dbbff4

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,2 @@
 android.useAndroidX=true
 org.gradle.jvmargs=-Xmx1024m
-
-systemProp.sonar.host.url=http://localhost:9000/
-systemProp.sonar.login=squ_4a8298fce62e10c463f5b14aef009aa7c7a5af37

--- a/src/main/java/de/dennisguse/opentracks/TrackStoppedActivity.java
+++ b/src/main/java/de/dennisguse/opentracks/TrackStoppedActivity.java
@@ -109,8 +109,8 @@ public class TrackStoppedActivity extends AbstractTrackDeleteActivity implements
                 viewBinding.trackEditActivityType.getText().toString(), viewBinding.trackEditDescription.getText().toString(),
                 contentProviderUtils);
     }
-
-    @Override
+//Deprecated this method beacause its deprecated
+    @Deprecated
     public void onBackPressed() {
         if (isDiscarding) {
             return;

--- a/src/main/java/de/dennisguse/opentracks/io/file/exporter/ExportActivity.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/exporter/ExportActivity.java
@@ -32,7 +32,6 @@ import androidx.documentfile.provider.DocumentFile;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.LinkedBlockingQueue;
-import java.util.stream.Collectors;
 
 import de.dennisguse.opentracks.R;
 import de.dennisguse.opentracks.data.ContentProviderUtils;
@@ -232,9 +231,9 @@ public class ExportActivity extends AppCompatActivity implements ExportService.E
         exportTasks = new ArrayList<>();
         if (allInOneFile) {
             String filename = "OpenTracks-Backup";
-            exportTasks.add(new ExportTask(filename, trackFileFormat, tracks.stream().map(Track::getId).collect(Collectors.toList())));
+            exportTasks.add(new ExportTask(filename, trackFileFormat, tracks.stream().map(Track::getId).toList()));
         } else {
-            exportTasks.addAll(tracks.stream().map(it -> new ExportTask(null, trackFileFormat, List.of(it.getId()))).collect(Collectors.toList()));
+            exportTasks.addAll(tracks.stream().map(it -> new ExportTask(null, trackFileFormat, List.of(it.getId()))).toList());
         }
         trackExportTotalCount = exportTasks.size();
     }

--- a/src/main/java/de/dennisguse/opentracks/io/file/exporter/KMLTrackExporter.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/exporter/KMLTrackExporter.java
@@ -239,7 +239,7 @@ public class KMLTrackExporter implements TrackExporter {
                                                 http://opentracksapp.com/xmlschemas/v1 http://opentracksapp.com/xmlschemas/OpenTracks_v1.xsd">
                         """); //TODO ADD xsi:schemaLocation for atom
         printWriter.println("<Document>");
-        printWriter.println("constant_variable");
+        printWriter.println(constant_variable);
         printWriter.println("<visibility>1</visibility>");
 
         Track track = tracks.get(0);
@@ -266,7 +266,7 @@ public class KMLTrackExporter implements TrackExporter {
     private void writeBeginMarkers(Track track) {
         printWriter.println("<Folder>");
         printWriter.println("<name>" + StringUtils.formatCData(context.getString(R.string.track_markers, track.getName())) + "</name>");
-        printWriter.println("constant_variable");
+        printWriter.println(constant_variable);
     }
 
     private void writeMarker(Marker marker, ZoneOffset zoneOffset) {
@@ -286,7 +286,7 @@ public class KMLTrackExporter implements TrackExporter {
     private void writeMultiTrackBegin() {
         printWriter.println("<Folder id=\"tracks\">");
         printWriter.println("<name>" + context.getString(R.string.generic_tracks) + "</name>");
-        printWriter.println("constant_variable");
+        printWriter.println(constant_variable);
     }
 
     private void writeMultiTrackEnd() {

--- a/src/main/java/de/dennisguse/opentracks/io/file/exporter/KMLTrackExporter.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/exporter/KMLTrackExporter.java
@@ -74,6 +74,7 @@ public class KMLTrackExporter implements TrackExporter {
     public static final String EXTENDED_DATA_TYPE_ACCURACY_HORIZONTAL = "accuracy_horizontal";
     public static final String EXTENDED_DATA_TYPE_ACCURACY_VERTICAL = "accuracy_vertical";
 
+    public static final String constant_variable= "<open>1</open>";
     private static final NumberFormat SENSOR_DATA_FORMAT = NumberFormat.getInstance(Locale.US);
 
     static {
@@ -238,7 +239,7 @@ public class KMLTrackExporter implements TrackExporter {
                                                 http://opentracksapp.com/xmlschemas/v1 http://opentracksapp.com/xmlschemas/OpenTracks_v1.xsd">
                         """); //TODO ADD xsi:schemaLocation for atom
         printWriter.println("<Document>");
-        printWriter.println("<open>1</open>");
+        printWriter.println("constant_variable");
         printWriter.println("<visibility>1</visibility>");
 
         Track track = tracks.get(0);
@@ -265,7 +266,7 @@ public class KMLTrackExporter implements TrackExporter {
     private void writeBeginMarkers(Track track) {
         printWriter.println("<Folder>");
         printWriter.println("<name>" + StringUtils.formatCData(context.getString(R.string.track_markers, track.getName())) + "</name>");
-        printWriter.println("<open>1</open>");
+        printWriter.println("constant_variable");
     }
 
     private void writeMarker(Marker marker, ZoneOffset zoneOffset) {
@@ -285,7 +286,7 @@ public class KMLTrackExporter implements TrackExporter {
     private void writeMultiTrackBegin() {
         printWriter.println("<Folder id=\"tracks\">");
         printWriter.println("<name>" + context.getString(R.string.generic_tracks) + "</name>");
-        printWriter.println("<open>1</open>");
+        printWriter.println("constant_variable");
     }
 
     private void writeMultiTrackEnd() {

--- a/src/main/java/de/dennisguse/opentracks/io/file/exporter/KmzTrackExporter.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/exporter/KmzTrackExporter.java
@@ -83,6 +83,7 @@ public class KmzTrackExporter implements TrackExporter {
             return true;
         } catch (InterruptedException | IOException e) {
             Log.e(TAG, "Unable to write track", e);
+            Thread.currentThread().interrupt();
             return false;
         }
     }

--- a/src/main/java/de/dennisguse/opentracks/io/file/importer/ImportActivity.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/importer/ImportActivity.java
@@ -47,7 +47,6 @@ import de.dennisguse.opentracks.util.IntentUtils;
  */
 public class ImportActivity extends FragmentActivity {
 
-    private static final String TAG = ImportActivity.class.getSimpleName();
 
     public static final String EXTRA_DIRECTORY_URI_KEY = "directory_uri";
 

--- a/src/main/java/de/dennisguse/opentracks/io/file/importer/ImportService.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/importer/ImportService.java
@@ -54,7 +54,7 @@ public class ImportService extends JobIntentService {
         String fileExtension = FileUtils.getExtension(file);
         try {
             Distance maxRecordingDistance = PreferencesUtils.getMaxRecordingDistance();
-            Distance recordingDistanceInterval = PreferencesUtils.getRecordingDistanceInterval();
+//            Distance recordingDistanceInterval = PreferencesUtils.getRecordingDistanceInterval();
             boolean preventReimport = PreferencesUtils.getPreventReimportTracks();
 
             TrackImporter trackImporter = new TrackImporter(this, new ContentProviderUtils(this), maxRecordingDistance, preventReimport);

--- a/src/main/java/de/dennisguse/opentracks/io/file/importer/ImportViewModel.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/importer/ImportViewModel.java
@@ -49,7 +49,7 @@ public class ImportViewModel extends AndroidViewModel implements ImportServiceRe
     private void loadData(List<DocumentFile> documentFiles) {
         List<ArrayList<DocumentFile>> nestedFileList = documentFiles.stream()
                 .map(FileUtils::getFiles)
-                .collect(Collectors.toList());
+                .toList();
 
         List<DocumentFile> fileList = new ArrayList<>();
         nestedFileList.forEach(fileList::addAll);

--- a/src/main/java/de/dennisguse/opentracks/io/file/importer/KmlTrackImporter.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/importer/KmlTrackImporter.java
@@ -77,7 +77,7 @@ public class KmlTrackImporter extends DefaultHandler implements XMLImporter.Trac
     private static final String TAG_PHOTO_OVERLAY = "PhotoOverlay";
     private static final String TAG_PLACEMARK = "Placemark";
     private static final String TAG_STYLE_URL = "styleUrl";
-    //    private static final String TAG_VALUE = "value"; TODO
+    //    private static final String TAG_VALUE = "value";
     private static final String TAG_WHEN = "when";
     private static final String TAG_UUID = "opentracks:trackid";
 
@@ -258,7 +258,7 @@ public class KmlTrackImporter extends DefaultHandler implements XMLImporter.Trac
             return;
         }
 
-        Marker marker = new Marker(null, new TrackPoint(TrackPoint.Type.TRACKPOINT, location, whenList.get(0))); //TODO Creating marker without need
+        Marker marker = new Marker(null, new TrackPoint(TrackPoint.Type.TRACKPOINT, location, whenList.get(0)));
         marker.setName(name != null ? name : "");
         marker.setDescription(description != null ? description : "");
         marker.setCategory(activityTypeLocalized != null ? activityTypeLocalized : "");

--- a/src/main/java/de/dennisguse/opentracks/io/file/importer/XMLImporter.java
+++ b/src/main/java/de/dennisguse/opentracks/io/file/importer/XMLImporter.java
@@ -47,7 +47,7 @@ public class XMLImporter {
             return parser.getImportTrackIds();
         } catch (SAXException | ParserConfigurationException | ParsingException e) {
             Log.e(TAG, "Unable to import file", e);
-            if (parser.getImportTrackIds().size() > 0) {
+            if (parser.getImportTrackIds().isEmpty()) {
                 parser.cleanImport();
             }
             throw new ImportParserException(e);


### PR DESCRIPTION
This PR consists of changes for issues resolved by Group9.

[#1](https://github.com/tarekFerdous/OpenTracks-Winter-SOEN-6431_2024_G9/issues/1) Define a constant instead of duplicating this literal "<open>1</open>" 3 times.
[#2](https://github.com/tarekFerdous/OpenTracks-Winter-SOEN-6431_2024_G9/issues/2) Replace this usage of 'Stream.collect(Collectors.toList())' with 'Stream.toList()' Group 09 
[#6](https://github.com/tarekFerdous/OpenTracks-Winter-SOEN-6431_2024_G9/issues/6) Either re-interrupt this method or rethrow the "InterruptedException" that can be caught here.
[#9](https://github.com/tarekFerdous/OpenTracks-Winter-SOEN-6431_2024_G9/issues/9) Remove unused "TAG" private field.
[#11](https://github.com/tarekFerdous/OpenTracks-Winter-SOEN-6431_2024_G9/issues/11) Use isEmpty() to check whether the collection is empty or not.
[#13](https://github.com/tarekFerdous/OpenTracks-Winter-SOEN-6431_2024_G9/issues/13) Fixing technical debts for io/file/impoter/importService.java and io/file/importer/importViewModel.java
[#14](https://github.com/tarekFerdous/OpenTracks-Winter-SOEN-6431_2024_G9/issues/14) io/file/importer/KmlTrackImporter and io/file/importer/KmzTrackImporter
[#15](https://github.com/tarekFerdous/OpenTracks-Winter-SOEN-6431_2024_G9/issues/15) Removing the Deprecated lines in the code Group(09)