### PR TITLE
Feature: Announce Max Slope at End of Each Recording

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/services/TrackRecordingService.java
+++ b/src/main/java/de/dennisguse/opentracks/services/TrackRecordingService.java
@@ -84,6 +84,7 @@ public class TrackRecordingService extends Service implements TrackPointCreator.
             Pair<Track, Pair<TrackPoint, SensorDataSet>> data = trackRecordingManager.getDataForUI();
 
             voiceAnnouncementManager.announceStatisticsIfNeeded(data.first);
+            voiceAnnouncementManager.announceAfterRun(data.first);
 
             recordingDataObservable.postValue(new RecordingData(data.first, data.second.first, data.second.second));
 

--- a/src/main/java/de/dennisguse/opentracks/services/TrackRecordingService.java
+++ b/src/main/java/de/dennisguse/opentracks/services/TrackRecordingService.java
@@ -238,6 +238,11 @@ public class TrackRecordingService extends Service implements TrackPointCreator.
             return;
         }
 
+        // announce after recording
+        Pair<Track, Pair<TrackPoint, SensorDataSet>> data = trackRecordingManager.getDataForUI();
+
+        voiceAnnouncementManager.announceAfterRecording(data.first);
+
         // Set recording status
         updateRecordingStatus(STATUS_DEFAULT);
 

--- a/src/main/java/de/dennisguse/opentracks/services/announcement/TTSManager.java
+++ b/src/main/java/de/dennisguse/opentracks/services/announcement/TTSManager.java
@@ -154,24 +154,26 @@ public class TTSManager {
     public void stop() {
         // Shutdown the TextToSpeech engine after the current task is done
         if (tts != null) {
-            while (tts.isSpeaking()) {
-                try {
-                    Thread.sleep(200);
-                } catch (InterruptedException e) {
-                    e.printStackTrace();
+            Thread stopTTs = new Thread(new Runnable() {
+                @Override
+                public void run() {
+                    // Wait until the speaking task is completed
+                    while (tts.isSpeaking()) {
+                        try {
+                            Thread.sleep(50);
+                        } catch (InterruptedException e) {
+                            e.printStackTrace();
+                        }
+                    }
+                    // Shutdown the TextToSpeech engine after the current task is done
+                    tts.shutdown();
+                    tts = null;
                 }
-            }
+            });
 
-            tts.shutdown();
-            tts = null;
-        }
-
-        if (ttsFallback != null) {
-            ttsFallback.release();
-            ttsFallback = null;
+            stopTTs.start();
         }
     }
-
     private void onTtsReady() {
         Locale locale = Locale.getDefault();
         int languageAvailability = tts.isLanguageAvailable(locale);

--- a/src/main/java/de/dennisguse/opentracks/services/announcement/TTSManager.java
+++ b/src/main/java/de/dennisguse/opentracks/services/announcement/TTSManager.java
@@ -152,7 +152,16 @@ public class TTSManager {
     }
 
     public void stop() {
+        // Shutdown the TextToSpeech engine after the current task is done
         if (tts != null) {
+            while (tts.isSpeaking()) {
+                try {
+                    Thread.sleep(200);
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
+                }
+            }
+
             tts.shutdown();
             tts = null;
         }

--- a/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementManager.java
+++ b/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementManager.java
@@ -118,6 +118,19 @@ public class VoiceAnnouncementManager implements SharedPreferences.OnSharedPrefe
         voiceAnnouncement.announce(VoiceAnnouncementUtils.createIdle(context));
     }
 
+    public void announceAfterRecording(@NonNull Track track) {
+        if (shouldNotAnnounce()) {
+            return;
+        }
+
+        // add other check with and here
+        if (!PreferencesUtils.shouldVoiceAnnounceMaxSpeedRecording()) {
+            return;
+        }
+
+        voiceAnnouncement.announce(VoiceAnnouncementUtils.createAfterRecording(context,track.getTrackStatistics(),PreferencesUtils.getUnitSystem()));
+    }
+
     public void announceStatisticsIfNeeded(@NonNull Track track) {
         if (shouldNotAnnounce()) {
             return;

--- a/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementManager.java
+++ b/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementManager.java
@@ -124,7 +124,7 @@ public class VoiceAnnouncementManager implements SharedPreferences.OnSharedPrefe
         }
 
         // add other check with and here
-        if (!PreferencesUtils.shouldVoiceAnnounceMaxSpeedRecording() && !PreferencesUtils.shouldVoiceAnnounceMaxSlope() ) {
+        if (!PreferencesUtils.shouldVoiceAnnounceMaxSpeedRecording() && !PreferencesUtils.shouldVoiceAnnounceMaxSlope() && !PreferencesUtils.shouldVoiceAnnounceAverageSpeedRecording()) {
             return;
         }
 

--- a/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementManager.java
+++ b/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementManager.java
@@ -124,12 +124,15 @@ public class VoiceAnnouncementManager implements SharedPreferences.OnSharedPrefe
         }
 
         // add other check with and here
-        if (!PreferencesUtils.shouldVoiceAnnounceMaxSpeedRecording()) {
+        if (!PreferencesUtils.shouldVoiceAnnounceMaxSpeedRecording() && !PreferencesUtils.shouldVoiceAnnounceMaxSlope() ) {
             return;
         }
 
         voiceAnnouncement.announce(VoiceAnnouncementUtils.createAfterRecording(context,track.getTrackStatistics(),PreferencesUtils.getUnitSystem()));
+        voiceAnnouncement.announce(VoiceAnnouncementUtils.calculateMaxSlope());
+        
     }
+   
 
     public void announceStatisticsIfNeeded(@NonNull Track track) {
         if (shouldNotAnnounce()) {

--- a/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementManager.java
+++ b/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementManager.java
@@ -137,8 +137,21 @@ public class VoiceAnnouncementManager implements SharedPreferences.OnSharedPrefe
             return;
         }
 
-        //TODO: Once we have run data from other groups, only call this if we're at the end of a run
-        voiceAnnouncement.announce(VoiceAnnouncementUtils.createRunStatistics(context, track.getTrackStatistics(), PreferencesUtils.getUnitSystem()));
+        boolean announce = false;
+        this.trackStatistics = track.getTrackStatistics();
+        if (trackStatistics.getTotalDistance().greaterThan(nextTotalDistance)) {
+            updateNextTaskDistance();
+            announce = true;
+        }
+        if (!trackStatistics.getTotalTime().minus(nextTotalTime).isNegative()) {
+            updateNextDuration();
+            announce = true;
+        }
+
+        if (announce) {
+            //TODO: Once we have run data from other groups, change the conditions to only call this if we're at the end of a run
+            voiceAnnouncement.announce(VoiceAnnouncementUtils.createRunStatistics(context, track.getTrackStatistics(), PreferencesUtils.getUnitSystem()));
+        }
     }
 
     public void announceStatisticsIfNeeded(@NonNull Track track) {

--- a/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementManager.java
+++ b/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementManager.java
@@ -122,15 +122,11 @@ public class VoiceAnnouncementManager implements SharedPreferences.OnSharedPrefe
         if (shouldNotAnnounce()) {
             return;
         }
-
         // add other check with and here
-        if (!PreferencesUtils.shouldVoiceAnnounceMaxSpeedRecording() && !PreferencesUtils.shouldVoiceAnnounceMaxSlope() ) {
+        if (!PreferencesUtils.shouldVoiceAnnounceMaxSpeedRecording() && !PreferencesUtils.shouldVoiceAnnounceMaxSlope() && !PreferencesUtils.shouldVoiceAnnounceAveragesloperecording()  ) {
             return;
         }
-
         voiceAnnouncement.announce(VoiceAnnouncementUtils.createAfterRecording(context,track.getTrackStatistics(),PreferencesUtils.getUnitSystem()));
-        
-        
     }
    
 

--- a/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementManager.java
+++ b/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementManager.java
@@ -131,6 +131,16 @@ public class VoiceAnnouncementManager implements SharedPreferences.OnSharedPrefe
         voiceAnnouncement.announce(VoiceAnnouncementUtils.createAfterRecording(context,track.getTrackStatistics(),PreferencesUtils.getUnitSystem()));
     }
 
+
+    public void announceAfterRun(@NonNull Track track) {
+        if (shouldNotAnnounce()) {
+            return;
+        }
+
+        //TODO: Once we have run data from other groups, only call this if we're at the end of a run
+        voiceAnnouncement.announce(VoiceAnnouncementUtils.createRunStatistics(context, track.getTrackStatistics(), PreferencesUtils.getUnitSystem()));
+    }
+
     public void announceStatisticsIfNeeded(@NonNull Track track) {
         if (shouldNotAnnounce()) {
             return;

--- a/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementManager.java
+++ b/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementManager.java
@@ -124,7 +124,7 @@ public class VoiceAnnouncementManager implements SharedPreferences.OnSharedPrefe
         }
 
         // add other check with and here
-        if (!PreferencesUtils.shouldVoiceAnnounceMaxSpeedRecording()) {
+        if (!PreferencesUtils.shouldVoiceAnnounceMaxSpeedRecording() && !PreferencesUtils.shouldVoiceAnnounceTimeSkiedRecording()) {
             return;
         }
 

--- a/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementManager.java
+++ b/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementManager.java
@@ -129,7 +129,7 @@ public class VoiceAnnouncementManager implements SharedPreferences.OnSharedPrefe
         }
 
         voiceAnnouncement.announce(VoiceAnnouncementUtils.createAfterRecording(context,track.getTrackStatistics(),PreferencesUtils.getUnitSystem()));
-        voiceAnnouncement.announce(VoiceAnnouncementUtils.calculateMaxSlope());
+        
         
     }
    

--- a/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementUtils.java
@@ -5,6 +5,7 @@ import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnno
 import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnnounceAverageSpeedPace;
 import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnnounceLapHeartRate;
 import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnnounceLapSpeedPace;
+import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnnounceTimeSkiedRecording;
 import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnnounceMovingTime;
 import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnnounceTotalDistance;
 
@@ -91,14 +92,17 @@ class VoiceAnnouncementUtils {
             builder.append(".");
         }
 		
-		if(shouldVoiceAnnounceTimeSkiedRecording()) {
-			Duration movingTime = trackStatistics.getMovingTime();
-//			Duration movingTime = 10000;
-        if (shouldVoiceAnnounceMovingTime() && !movingTime.isZero()) {
-            appendDuration(context, builder, movingTime);
-            builder.append(".");
+
+        if (shouldVoiceAnnounceTimeSkiedRecording()) {
+            double timeSkied = calculateTimeSkied(); // Calculate the maximum slope based on elevation data
+            if (!Double.isNaN(timeSkied)) {
+                builder.append(" ")
+                        .append(context.getString(R.string.settings_announcements_time_skied_recording))
+                        .append(": ")
+                        .append(String.format("%.2f%%", timeSkied)) // Format the slope value
+                        .append(".");
+            }
         }
-		}
 
 
         return builder;

--- a/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementUtils.java
@@ -36,7 +36,13 @@ class VoiceAnnouncementUtils {
     private VoiceAnnouncementUtils() {
     }
 
-    static Spannable createIdle(Context context) {
+    static double calculateTimeSkied() {
+
+           return 0.0; 
+		   
+    }
+	
+	static Spannable createIdle(Context context) {
         return new SpannableStringBuilder()
                 .append(context.getString(R.string.voiceIdle));
     }

--- a/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementUtils.java
@@ -9,9 +9,8 @@ import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnno
 import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnnounceTotalDistance;
 import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnnounceRunAverageSpeed;
 import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnnounceMaxSlope;
-
-
 import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnnounceMaxSpeedRecording;
+import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnnounceAverageSpeedRecording;
 
 import android.content.Context;
 import android.icu.text.MessageFormat;
@@ -42,6 +41,11 @@ class VoiceAnnouncementUtils {
        
         // This method should return the calculated maximum slope.
            return 0.0; 
+    }
+
+    static double calculateAverageSpeed(){
+        // This is dummy methods to fetch or calculate the average slope.
+        return 5.0;
     }
 
     static Spannable createIdle(Context context) {
@@ -103,7 +107,18 @@ class VoiceAnnouncementUtils {
                .append(".");
             }
         }
-       
+
+        if (shouldVoiceAnnounceAverageSpeedRecording()) {
+            double avgSpeed = calculateMaxSlope();
+            if (!Double.isNaN(avgSpeed)) {
+                builder.append(" ")
+                        .append("Average speed")
+                        .append(" ")
+                        .append(": ")
+                        .append(String.format("%.2f%%", avgSpeed))
+                        .append(".");
+            }
+        }
 
         return builder;
     }

--- a/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementUtils.java
@@ -41,7 +41,7 @@ class VoiceAnnouncementUtils {
         // This method should return the calculated maximum slope.
            return 0.0; 
     }
-    static double CalculateAvergeaSlope(){
+    static double CalculateAverageSlope(){
         // This is dummy methods to fetch or calculate the average slope.
         return 10.0;
     }
@@ -106,11 +106,10 @@ class VoiceAnnouncementUtils {
             }
         }
             if (shouldVoiceAnnounceAveragesloperecording()) {
-                double avgSlope = calculateMaxSlope();
+                double avgSlope = CalculateAverageSlope();
                 if (!Double.isNaN(avgSlope)) {
                     builder.append(" ")
                             .append("Average slope")
-                            .append(" ")
                             .append(": ")
                             .append(String.format("%.2f%%", avgSlope))
                             .append(".");

--- a/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementUtils.java
@@ -43,6 +43,7 @@ class VoiceAnnouncementUtils {
         SpannableStringBuilder builder = new SpannableStringBuilder();
         Distance totalDistance = trackStatistics.getTotalDistance();
         Speed averageMovingSpeed = trackStatistics.getAverageMovingSpeed();
+        Speed maxSpeed = trackStatistics.getMaxSpeed();
         Speed currentDistancePerTime = currentInterval != null ? currentInterval.getSpeed() : null;
 
         int perUnitStringId;
@@ -106,6 +107,14 @@ class VoiceAnnouncementUtils {
                 appendDecimalUnit(builder, MessageFormat.format(template, Map.of("n", speedInUnit)), speedInUnit, 1, unitSpeedTTS);
                 builder.append(".");
             }
+            if (shouldVoiceAnnounceMaxSpeedRun()) {
+                double speedInUnit = maxSpeed.to(unitSystem);
+                builder.append(" ")
+                        .append(context.getString(R.string.speed));
+                String template = context.getResources().getString(speedId);
+                appendDecimalUnit(builder, MessageFormat.format(template, Map.of("n", speedInUnit)), speedInUnit, 1, unitSpeedTTS);
+                builder.append(".");
+            }
             if (shouldVoiceAnnounceLapSpeedPace() && currentDistancePerTime != null) {
                 double currentDistancePerTimeInUnit = currentDistancePerTime.to(unitSystem);
                 if (currentDistancePerTimeInUnit > 0) {
@@ -119,6 +128,16 @@ class VoiceAnnouncementUtils {
         } else {
             if (shouldVoiceAnnounceAverageSpeedPace()) {
                 Duration time = averageMovingSpeed.toPace(unitSystem);
+                builder.append(" ")
+                        .append(context.getString(R.string.pace));
+                appendDuration(context, builder, time);
+                builder.append(" ")
+                        .append(context.getString(perUnitStringId))
+                        .append(".");
+            }
+
+            if (shouldVoiceAnnounceMaxSpeedRun()) {
+                Duration time = maxSpeed.toPace(unitSystem);
                 builder.append(" ")
                         .append(context.getString(R.string.pace));
                 appendDuration(context, builder, time);

--- a/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementUtils.java
@@ -126,6 +126,7 @@ class VoiceAnnouncementUtils {
         //TODO: Once we get run data from other groups, we can announce run statistics instead of track statistics
         Distance totalDistance = trackStatistics.getTotalDistance();
         Speed averageMovingSpeed = trackStatistics.getAverageMovingSpeed();
+        Speed maxSpeed = trackStatistics.getMaxSpeed();
 
         int speedId;
         String unitSpeedTTS;
@@ -145,9 +146,7 @@ class VoiceAnnouncementUtils {
             default -> throw new RuntimeException("Not implemented");
         }
 
-        if (totalDistance.isZero()) {
-            return builder;
-        }
+
 
         //Announce Average Speed
        if (shouldVoiceAnnounceRunAverageSpeed()) {
@@ -158,14 +157,23 @@ class VoiceAnnouncementUtils {
            appendDecimalUnit(builder, MessageFormat.format(template, Map.of("n", speedInUnit)), speedInUnit, 1, unitSpeedTTS);
            builder.append(".");
        }
-       return builder;
+
+        if (shouldVoiceAnnounceMaxSpeedRun()) {
+            double speedInUnit = maxSpeed.to(unitSystem);
+            builder.append(" ")
+                    .append(context.getString(R.string.settings_announcements_max_speed_run));
+            String template = context.getResources().getString(speedId);
+            appendDecimalUnit(builder, MessageFormat.format(template, Map.of("n", speedInUnit)), speedInUnit, 1, unitSpeedTTS);
+            builder.append(".");
+        }
+        return builder;
     }
 
     static Spannable createStatistics(Context context, TrackStatistics trackStatistics, UnitSystem unitSystem, boolean isReportSpeed, @Nullable IntervalStatistics.Interval currentInterval, @Nullable SensorStatistics sensorStatistics) {
         SpannableStringBuilder builder = new SpannableStringBuilder();
         Distance totalDistance = trackStatistics.getTotalDistance();
         Speed averageMovingSpeed = trackStatistics.getAverageMovingSpeed();
-        Speed maxSpeed = trackStatistics.getMaxSpeed();
+
         Speed currentDistancePerTime = currentInterval != null ? currentInterval.getSpeed() : null;
 
         int perUnitStringId;
@@ -229,14 +237,7 @@ class VoiceAnnouncementUtils {
                 appendDecimalUnit(builder, MessageFormat.format(template, Map.of("n", speedInUnit)), speedInUnit, 1, unitSpeedTTS);
                 builder.append(".");
             }
-            if (shouldVoiceAnnounceMaxSpeedRun()) {
-                double speedInUnit = maxSpeed.to(unitSystem);
-                builder.append(" ")
-                        .append(context.getString(R.string.speed));
-                String template = context.getResources().getString(speedId);
-                appendDecimalUnit(builder, MessageFormat.format(template, Map.of("n", speedInUnit)), speedInUnit, 1, unitSpeedTTS);
-                builder.append(".");
-            }
+
             if (shouldVoiceAnnounceLapSpeedPace() && currentDistancePerTime != null) {
                 double currentDistancePerTimeInUnit = currentDistancePerTime.to(unitSystem);
                 if (currentDistancePerTimeInUnit > 0) {
@@ -258,15 +259,6 @@ class VoiceAnnouncementUtils {
                         .append(".");
             }
 
-            if (shouldVoiceAnnounceMaxSpeedRun()) {
-                Duration time = maxSpeed.toPace(unitSystem);
-                builder.append(" ")
-                        .append(context.getString(R.string.pace));
-                appendDuration(context, builder, time);
-                builder.append(" ")
-                        .append(context.getString(perUnitStringId))
-                        .append(".");
-            }
 
             if (shouldVoiceAnnounceLapSpeedPace() && currentDistancePerTime != null) {
                 Duration currentTime = currentDistancePerTime.toPace(unitSystem);

--- a/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementUtils.java
@@ -7,6 +7,7 @@ import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnno
 import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnnounceLapSpeedPace;
 import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnnounceMovingTime;
 import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnnounceTotalDistance;
+import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnnounceMaxSpeedRun;
 
 import android.content.Context;
 import android.icu.text.MessageFormat;

--- a/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementUtils.java
@@ -9,6 +9,7 @@ import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnno
 import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnnounceTotalDistance;
 
 import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnnounceMaxSpeedRecording;
+import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnnounceTimeSkiedRecording;
 
 import android.content.Context;
 import android.icu.text.MessageFormat;
@@ -83,6 +84,15 @@ class VoiceAnnouncementUtils {
             appendDecimalUnit(builder, MessageFormat.format(template, Map.of("n", speedInUnit)), speedInUnit, 1, unitSpeedTTS);
             builder.append(".");
         }
+		
+		if(shouldVoiceAnnounceTimeSkiedRecording()) {
+			Duration movingTime = trackStatistics.getMovingTime();
+//			Duration movingTime = 10000;
+        if (shouldVoiceAnnounceMovingTime() && !movingTime.isZero()) {
+            appendDuration(context, builder, movingTime);
+            builder.append(".");
+        }
+		}
 
 
         return builder;

--- a/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementUtils.java
@@ -7,6 +7,7 @@ import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnno
 import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnnounceLapSpeedPace;
 import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnnounceMovingTime;
 import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnnounceTotalDistance;
+import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnnounceMaxSlope;
 
 import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnnounceMaxSpeedRecording;
 
@@ -33,6 +34,12 @@ import de.dennisguse.opentracks.ui.intervals.IntervalStatistics;
 class VoiceAnnouncementUtils {
 
     private VoiceAnnouncementUtils() {
+    }
+    
+    static double calculateMaxSlope() {
+       
+        // This method should return the calculated maximum slope.
+           return 0.0; 
     }
 
     static Spannable createIdle(Context context) {
@@ -203,6 +210,17 @@ class VoiceAnnouncementUtils {
             appendCardinal(builder, context.getString(R.string.sensor_state_heart_rate_value, currentHeartRate), currentHeartRate);
             builder.append(".");
         }
+        if (shouldVoiceAnnounceMaxSlope()) {
+            double maxSlope = calculateMaxSlope(); // Calculate the maximum slope based on elevation data
+            if (!Double.isNaN(maxSlope)) {
+                builder.append(" ")
+               .append(context.getString(R.string.settings_announcements_max_slope))
+               .append(": ")
+               .append(String.format("%.2f%%", maxSlope)) // Format the slope value
+               .append(".");
+            }
+        }
+
 
         return builder;
     }

--- a/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementUtils.java
@@ -7,7 +7,7 @@ import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnno
 import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnnounceLapSpeedPace;
 import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnnounceMovingTime;
 import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnnounceTotalDistance;
-import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnnounceRunAvgSpeed;
+import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnnounceRunAverageSpeed;
 
 import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnnounceMaxSpeedRecording;
 
@@ -87,6 +87,46 @@ class VoiceAnnouncementUtils {
 
 
         return builder;
+    }
+
+    static Spannable createRunStatistics(Context context, TrackStatistics trackStatistics, UnitSystem unitSystem) {
+        SpannableStringBuilder builder = new SpannableStringBuilder();
+        //TODO: Once we get run data from other groups, we can announce run statistics instead of track statistics
+        Distance totalDistance = trackStatistics.getTotalDistance();
+        Speed averageMovingSpeed = trackStatistics.getAverageMovingSpeed();
+
+        int speedId;
+        String unitSpeedTTS;
+        switch (unitSystem) {
+            case METRIC -> {
+                speedId = R.string.voiceSpeedKilometersPerHourPlural;
+                unitSpeedTTS = "kilometer per hour";
+            }
+            case IMPERIAL_FEET, IMPERIAL_METER -> {
+                speedId = R.string.voiceSpeedMilesPerHourPlural;
+                unitSpeedTTS = "mile per hour";
+            }
+            case NAUTICAL_IMPERIAL -> {
+                speedId = R.string.voiceSpeedMKnotsPlural;
+                unitSpeedTTS = "knots";
+            }
+            default -> throw new RuntimeException("Not implemented");
+        }
+
+        if (totalDistance.isZero()) {
+            return builder;
+        }
+
+        //Announce Average Speed
+       if (shouldVoiceAnnounceRunAverageSpeed()) {
+           double speedInUnit = averageMovingSpeed.to(unitSystem);
+           builder.append(" ")
+                   .append(context.getString(R.string.speed));
+           String template = context.getResources().getString(speedId);
+           appendDecimalUnit(builder, MessageFormat.format(template, Map.of("n", speedInUnit)), speedInUnit, 1, unitSpeedTTS);
+           builder.append(".");
+       }
+       return builder;
     }
 
     static Spannable createStatistics(Context context, TrackStatistics trackStatistics, UnitSystem unitSystem, boolean isReportSpeed, @Nullable IntervalStatistics.Interval currentInterval, @Nullable SensorStatistics sensorStatistics) {

--- a/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementUtils.java
@@ -7,6 +7,7 @@ import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnno
 import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnnounceLapSpeedPace;
 import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnnounceMovingTime;
 import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnnounceTotalDistance;
+import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnnounceRunAvgSpeed;
 
 import android.content.Context;
 import android.icu.text.MessageFormat;

--- a/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementUtils.java
@@ -11,7 +11,7 @@ import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnno
 import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnnounceRunAverageSpeed;
 import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnnounceMaxSlope;
 import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnnounceAveragesloperecording;
-
+import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnnounceAverageslopeRun;
 import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnnounceMaxSpeedRecording;
 
 import android.content.Context;
@@ -127,7 +127,6 @@ class VoiceAnnouncementUtils {
         Distance totalDistance = trackStatistics.getTotalDistance();
         Speed averageMovingSpeed = trackStatistics.getAverageMovingSpeed();
         Speed maxSpeed = trackStatistics.getMaxSpeed();
-
         int speedId;
         String unitSpeedTTS;
         switch (unitSystem) {
@@ -165,6 +164,16 @@ class VoiceAnnouncementUtils {
             String template = context.getResources().getString(speedId);
             appendDecimalUnit(builder, MessageFormat.format(template, Map.of("n", speedInUnit)), speedInUnit, 1, unitSpeedTTS);
             builder.append(".");
+        }
+        if (shouldVoiceAnnounceAverageslopeRun()) {
+            double avgSlope = CalculateAverageSlope();
+            if (!Double.isNaN(avgSlope)) {
+                builder.append(" ")
+                        .append("Average slope")
+                        .append(": ")
+                        .append(String.format("%.2f%%", avgSlope))
+                        .append(".");
+            }
         }
         return builder;
     }

--- a/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementUtils.java
@@ -7,7 +7,6 @@ import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnno
 import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnnounceLapSpeedPace;
 import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnnounceMovingTime;
 import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnnounceTotalDistance;
-import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnnounceMaxSlope; 
 
 import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnnounceMaxSpeedRecording;
 
@@ -203,16 +202,6 @@ class VoiceAnnouncementUtils {
                     .append(context.getString(R.string.current_heart_rate));
             appendCardinal(builder, context.getString(R.string.sensor_state_heart_rate_value, currentHeartRate), currentHeartRate);
             builder.append(".");
-        }
-        if (shouldVoiceAnnounceMaxSlope()) {
-            double maxSlope = calculateMaxSlope(); // Calculate the maximum slope based on elevation data
-            if (!Double.isNaN(maxSlope)) {
-                builder.append(" ")
-               .append(context.getString(R.string.max_slope))
-               .append(": ")
-               .append(String.format("%.2f%%", maxSlope)) // Format the slope value
-               .append(".");
-            }
         }
 
         return builder;

--- a/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementUtils.java
@@ -8,6 +8,8 @@ import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnno
 import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnnounceMovingTime;
 import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnnounceTotalDistance;
 
+import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnnounceMaxSpeedRecording;
+
 import android.content.Context;
 import android.icu.text.MessageFormat;
 import android.text.Spannable;
@@ -36,6 +38,54 @@ class VoiceAnnouncementUtils {
     static Spannable createIdle(Context context) {
         return new SpannableStringBuilder()
                 .append(context.getString(R.string.voiceIdle));
+    }
+
+    static Spannable createAfterRecording(Context context, TrackStatistics trackStatistics, UnitSystem unitSystem) {
+        SpannableStringBuilder builder = new SpannableStringBuilder();
+        Speed maxSpeed = trackStatistics.getMaxSpeed();
+
+        int perUnitStringId;
+        int distanceId;
+        int speedId;
+        String unitDistanceTTS;
+        String unitSpeedTTS;
+        switch (unitSystem) {
+            case METRIC -> {
+                perUnitStringId = R.string.voice_per_kilometer;
+                distanceId = R.string.voiceDistanceKilometersPlural;
+                speedId = R.string.voiceSpeedKilometersPerHourPlural;
+                unitDistanceTTS = "kilometer";
+                unitSpeedTTS = "kilometer per hour";
+            }
+            case IMPERIAL_FEET, IMPERIAL_METER -> {
+                perUnitStringId = R.string.voice_per_mile;
+                distanceId = R.string.voiceDistanceMilesPlural;
+                speedId = R.string.voiceSpeedMilesPerHourPlural;
+                unitDistanceTTS = "mile";
+                unitSpeedTTS = "mile per hour";
+            }
+            case NAUTICAL_IMPERIAL -> {
+                perUnitStringId = R.string.voice_per_nautical_mile;
+                distanceId = R.string.voiceDistanceNauticalMilesPlural;
+                speedId = R.string.voiceSpeedMKnotsPlural;
+                unitDistanceTTS = "nautical mile";
+                unitSpeedTTS = "knots";
+            }
+            default -> throw new RuntimeException("Not implemented");
+        }
+
+
+        if (shouldVoiceAnnounceMaxSpeedRecording()) {
+            double speedInUnit = maxSpeed.to(unitSystem);
+            builder.append(" ")
+                    .append(context.getString(R.string.speed));
+            String template = context.getResources().getString(speedId);
+            appendDecimalUnit(builder, MessageFormat.format(template, Map.of("n", speedInUnit)), speedInUnit, 1, unitSpeedTTS);
+            builder.append(".");
+        }
+
+
+        return builder;
     }
 
     static Spannable createStatistics(Context context, TrackStatistics trackStatistics, UnitSystem unitSystem, boolean isReportSpeed, @Nullable IntervalStatistics.Interval currentInterval, @Nullable SensorStatistics sensorStatistics) {

--- a/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementUtils.java
@@ -38,21 +38,18 @@ class VoiceAnnouncementUtils {
 
     private VoiceAnnouncementUtils() {
     }
-    
+
     static double calculateMaxSlope() {
-       
+
         // This method should return the calculated maximum slope.
-           return 0.0; 
+        return 0.0;
     }
-    static double CalculateAverageSlope(){
+
+    static double CalculateAverageSlope() {
         // This is dummy methods to fetch or calculate the average slope.
         return 10.0;
     }
 
-    static double calculateAverageSpeed(){
-        // This is dummy methods to fetch or calculate the average slope.
-        return 5.0;
-    }
 
     static Spannable createIdle(Context context) {
         return new SpannableStringBuilder()
@@ -62,6 +59,7 @@ class VoiceAnnouncementUtils {
     static Spannable createAfterRecording(Context context, TrackStatistics trackStatistics, UnitSystem unitSystem) {
         SpannableStringBuilder builder = new SpannableStringBuilder();
         Speed maxSpeed = trackStatistics.getMaxSpeed();
+        Speed avgSpeed = trackStatistics.getAverageSpeed();
 
         int perUnitStringId;
         int distanceId;
@@ -97,7 +95,7 @@ class VoiceAnnouncementUtils {
         if (shouldVoiceAnnounceMaxSpeedRecording()) {
             double speedInUnit = maxSpeed.to(unitSystem);
             builder.append(" ")
-                    .append(context.getString(R.string.speed));
+                    .append(context.getString(R.string.stats_max_speed));
             String template = context.getResources().getString(speedId);
             appendDecimalUnit(builder, MessageFormat.format(template, Map.of("n", speedInUnit)), speedInUnit, 1, unitSpeedTTS);
             builder.append(".");
@@ -107,36 +105,34 @@ class VoiceAnnouncementUtils {
             double maxSlope = calculateMaxSlope(); // Calculate the maximum slope based on elevation data
             if (!Double.isNaN(maxSlope)) {
                 builder.append(" ")
-               .append(context.getString(R.string.settings_announcements_max_slope))
-               .append(": ")
-               .append(String.format("%.2f%%", maxSlope)) // Format the slope value
-               .append(".");
-            }
-        }
-
-        if (shouldVoiceAnnounceAverageSpeedRecording()) {
-            double avgSpeed = calculateMaxSlope();
-            if (!Double.isNaN(avgSpeed)) {
-                builder.append(" ")
-                        .append("Average speed")
-                        .append(" ")
+                        .append(context.getString(R.string.settings_announcements_max_slope))
                         .append(": ")
-                        .append(String.format("%.2f%%", avgSpeed))
+                        .append(String.format("%.2f%%", maxSlope)) // Format the slope value
                         .append(".");
             }
         }
 
+        if (shouldVoiceAnnounceAverageSpeedRecording()) {
 
-            if (shouldVoiceAnnounceAveragesloperecording()) {
-                double avgSlope = CalculateAverageSlope();
-                if (!Double.isNaN(avgSlope)) {
-                    builder.append(" ")
-                            .append("Average slope")
-                            .append(": ")
-                            .append(String.format("%.2f%%", avgSlope))
-                            .append(".");
-                }
+            double speedInUnit = avgSpeed.to(unitSystem);
+            builder.append(" ")
+                    .append(context.getString(R.string.speed));
+            String template = context.getResources().getString(speedId);
+            appendDecimalUnit(builder, MessageFormat.format(template, Map.of("n", speedInUnit)), speedInUnit, 1, unitSpeedTTS);
+            builder.append(".");
+        }
+
+
+        if (shouldVoiceAnnounceAveragesloperecording()) {
+            double avgSlope = CalculateAverageSlope();
+            if (!Double.isNaN(avgSlope)) {
+                builder.append(" ")
+                        .append("Average slope")
+                        .append(": ")
+                        .append(String.format("%.2f%%", avgSlope))
+                        .append(".");
             }
+        }
         return builder;
     }
 
@@ -166,21 +162,20 @@ class VoiceAnnouncementUtils {
         }
 
 
-
         //Announce Average Speed
-       if (shouldVoiceAnnounceRunAverageSpeed()) {
-           double speedInUnit = averageMovingSpeed.to(unitSystem);
-           builder.append(" ")
-                   .append(context.getString(R.string.speed));
-           String template = context.getResources().getString(speedId);
-           appendDecimalUnit(builder, MessageFormat.format(template, Map.of("n", speedInUnit)), speedInUnit, 1, unitSpeedTTS);
-           builder.append(".");
-       }
+        if (shouldVoiceAnnounceRunAverageSpeed()) {
+            double speedInUnit = averageMovingSpeed.to(unitSystem);
+            builder.append(" ")
+                    .append(context.getString(R.string.speed));
+            String template = context.getResources().getString(speedId);
+            appendDecimalUnit(builder, MessageFormat.format(template, Map.of("n", speedInUnit)), speedInUnit, 1, unitSpeedTTS);
+            builder.append(".");
+        }
 
         if (shouldVoiceAnnounceMaxSpeedRun()) {
             double speedInUnit = maxSpeed.to(unitSystem);
             builder.append(" ")
-                    .append(context.getString(R.string.settings_announcements_max_speed_run));
+                    .append(context.getString(R.string.stats_max_speed));
             String template = context.getResources().getString(speedId);
             appendDecimalUnit(builder, MessageFormat.format(template, Map.of("n", speedInUnit)), speedInUnit, 1, unitSpeedTTS);
             builder.append(".");
@@ -306,7 +301,6 @@ class VoiceAnnouncementUtils {
             appendCardinal(builder, context.getString(R.string.sensor_state_heart_rate_value, currentHeartRate), currentHeartRate);
             builder.append(".");
         }
-        
 
 
         return builder;
@@ -334,7 +328,7 @@ class VoiceAnnouncementUtils {
     /**
      * Speaks as: 98.14 [UNIT] - ninety eight point one four [UNIT with correct plural form]
      *
-     * @param number The number to speak
+     * @param number    The number to speak
      * @param precision The number of decimal places to announce
      */
     private static void appendDecimalUnit(@NonNull SpannableStringBuilder builder, @NonNull String localizedText, double number, int precision, @NonNull String unit) {
@@ -346,7 +340,7 @@ class VoiceAnnouncementUtils {
         long integerPart = (long) roundedNumber;
 
         if (precision == 0 || (roundedNumber - integerPart) == 0) {
-            measureBuilder.setNumber((long)number);
+            measureBuilder.setNumber((long) number);
         } else {
             // Extract the decimal part
             String fractionalPart = String.format("%." + precision + "f", (roundedNumber - integerPart)).substring(2);

--- a/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementUtils.java
@@ -8,7 +8,7 @@ import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnno
 import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnnounceMovingTime;
 import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnnounceTotalDistance;
 import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnnounceMaxSlope;
-
+import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnnounceAveragesloperecording;
 import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnnounceMaxSpeedRecording;
 
 import android.content.Context;
@@ -40,6 +40,10 @@ class VoiceAnnouncementUtils {
        
         // This method should return the calculated maximum slope.
            return 0.0; 
+    }
+    static double CalculateAvergeaSlope(){
+        // This is dummy methods to fetch or calculate the average slope.
+        return 10.0;
     }
 
     static Spannable createIdle(Context context) {
@@ -101,8 +105,17 @@ class VoiceAnnouncementUtils {
                .append(".");
             }
         }
-       
-
+            if (shouldVoiceAnnounceAveragesloperecording()) {
+                double avgSlope = calculateMaxSlope();
+                if (!Double.isNaN(avgSlope)) {
+                    builder.append(" ")
+                            .append("Average slope")
+                            .append(" ")
+                            .append(": ")
+                            .append(String.format("%.2f%%", avgSlope))
+                            .append(".");
+                }
+            }
         return builder;
     }
 

--- a/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementUtils.java
@@ -91,6 +91,17 @@ class VoiceAnnouncementUtils {
             builder.append(".");
         }
 
+        if (shouldVoiceAnnounceMaxSlope()) {
+            double maxSlope = calculateMaxSlope(); // Calculate the maximum slope based on elevation data
+            if (!Double.isNaN(maxSlope)) {
+                builder.append(" ")
+               .append(context.getString(R.string.settings_announcements_max_slope))
+               .append(": ")
+               .append(String.format("%.2f%%", maxSlope)) // Format the slope value
+               .append(".");
+            }
+        }
+       
 
         return builder;
     }
@@ -210,16 +221,7 @@ class VoiceAnnouncementUtils {
             appendCardinal(builder, context.getString(R.string.sensor_state_heart_rate_value, currentHeartRate), currentHeartRate);
             builder.append(".");
         }
-        if (shouldVoiceAnnounceMaxSlope()) {
-            double maxSlope = calculateMaxSlope(); // Calculate the maximum slope based on elevation data
-            if (!Double.isNaN(maxSlope)) {
-                builder.append(" ")
-               .append(context.getString(R.string.settings_announcements_max_slope))
-               .append(": ")
-               .append(String.format("%.2f%%", maxSlope)) // Format the slope value
-               .append(".");
-            }
-        }
+        
 
 
         return builder;

--- a/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/services/announcement/VoiceAnnouncementUtils.java
@@ -7,6 +7,7 @@ import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnno
 import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnnounceLapSpeedPace;
 import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnnounceMovingTime;
 import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnnounceTotalDistance;
+import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnnounceMaxSlope; 
 
 import static de.dennisguse.opentracks.settings.PreferencesUtils.shouldVoiceAnnounceMaxSpeedRecording;
 
@@ -202,6 +203,16 @@ class VoiceAnnouncementUtils {
                     .append(context.getString(R.string.current_heart_rate));
             appendCardinal(builder, context.getString(R.string.sensor_state_heart_rate_value, currentHeartRate), currentHeartRate);
             builder.append(".");
+        }
+        if (shouldVoiceAnnounceMaxSlope()) {
+            double maxSlope = calculateMaxSlope(); // Calculate the maximum slope based on elevation data
+            if (!Double.isNaN(maxSlope)) {
+                builder.append(" ")
+               .append(context.getString(R.string.max_slope))
+               .append(": ")
+               .append(String.format("%.2f%%", maxSlope)) // Format the slope value
+               .append(".");
+            }
         }
 
         return builder;

--- a/src/main/java/de/dennisguse/opentracks/settings/PreferencesUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/settings/PreferencesUtils.java
@@ -445,6 +445,7 @@ public class PreferencesUtils {
         return getBoolean(R.string.voice_announce_max_speed_run_key, true);
     }
 
+
     @VisibleForTesting
     public static void setVoiceAnnounceMaxSpeedRun(boolean value) {
         setBoolean(R.string.voice_announce_max_speed_run_key, value);
@@ -478,12 +479,21 @@ public class PreferencesUtils {
     public static void setVoiceAnnounceMaxSpeedRecording(boolean value) {
         setBoolean(R.string.voice_announce_max_speed_recording_key, value);
     }
-    //recording related data for average slope's helper methods
+    //recording related data for average slope's helper methods for each recording
     public static boolean shouldVoiceAnnounceAveragesloperecording() {
         return getBoolean(R.string.voice_announce_average_slope_recording_key, true);
     }
     @VisibleForTesting
     public static void setVoiceAnnounceAveragesloperecording(boolean value) {
+        setBoolean(R.string.voice_announce_average_slope_recording_key, value);
+
+    }
+    //recording related data for average slope's helper methods for each run
+    public static boolean shouldVoiceAnnounceAverageslopeRun() {
+        return getBoolean(R.string.voice_announce_average_slope_recording_key, true);
+    }
+    @VisibleForTesting
+    public static void setVoiceAnnounceAverageslopeRun(boolean value) {
         setBoolean(R.string.voice_announce_average_slope_recording_key, value);
 
     }

--- a/src/main/java/de/dennisguse/opentracks/settings/PreferencesUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/settings/PreferencesUtils.java
@@ -449,6 +449,16 @@ public class PreferencesUtils {
     public static void setVoiceAnnounceMaxSpeedRecording(boolean value) {
         setBoolean(R.string.voice_announce_max_speed_recording_key, value);
     }
+	
+	    // recoding related setting helper methods
+    public static boolean shouldVoiceAnnounceTimeSkiedRecording() {
+        return getBoolean(R.string.voice_announce_time_skied_recording_key, true);
+    }
+
+    @VisibleForTesting
+    public static void setVoiceAnnounceTimeSkiedRecording(boolean value) {
+        setBoolean(R.string.voice_announce_time_skied_recording_key, value);
+    }
 
     public static Distance getRecordingDistanceInterval() {
         return Distance.of(getInt(R.string.recording_distance_interval_key, getRecordingDistanceIntervalDefaultInternal()));

--- a/src/main/java/de/dennisguse/opentracks/settings/PreferencesUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/settings/PreferencesUtils.java
@@ -440,6 +440,15 @@ public class PreferencesUtils {
         setBoolean(R.string.voice_announce_average_heart_rate_key, value);
     }
 
+    public static boolean shouldVoiceAnnounceMaxSpeedRun() {
+        return getBoolean(R.string.voice_announce_max_speed_run_key, true);
+    }
+
+    @VisibleForTesting
+    public static void setVoiceAnnounceMaxSpeedRun(boolean value) {
+        setBoolean(R.string.voice_announce_max_speed_run_key, value);
+    }
+
     public static Distance getRecordingDistanceInterval() {
         return Distance.of(getInt(R.string.recording_distance_interval_key, getRecordingDistanceIntervalDefaultInternal()));
     }

--- a/src/main/java/de/dennisguse/opentracks/settings/PreferencesUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/settings/PreferencesUtils.java
@@ -440,6 +440,15 @@ public class PreferencesUtils {
         setBoolean(R.string.voice_announce_average_heart_rate_key, value);
     }
 
+    public static boolean shouldVoiceAnnounceRunAverageSpeed() {
+        return getBoolean(R.string.voice_announce_run_average_speed_key, true);
+    }
+
+    @VisibleForTesting
+    public static void setVoiceAnnounceRunAverageSpeed(boolean value) {
+        setBoolean(R.string.voice_announce_run_average_speed_key, value);
+    }
+
     public static Distance getRecordingDistanceInterval() {
         return Distance.of(getInt(R.string.recording_distance_interval_key, getRecordingDistanceIntervalDefaultInternal()));
     }

--- a/src/main/java/de/dennisguse/opentracks/settings/PreferencesUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/settings/PreferencesUtils.java
@@ -450,9 +450,14 @@ public class PreferencesUtils {
         setBoolean(R.string.voice_announce_max_speed_recording_key, value);
     }
 	
-	    // recoding related setting helper methods
+	// recoding related setting helper methods
     public static boolean shouldVoiceAnnounceTimeSkiedRecording() {
         return getBoolean(R.string.voice_announce_time_skied_recording_key, true);
+    }
+	
+	@VisibleForTesting
+    public static void setVoiceAnnounceTimeSkiedRecording(boolean value) {
+        setBoolean(R.string.voice_announce_time_skied_recording_key, value);
     }
 
     @VisibleForTesting

--- a/src/main/java/de/dennisguse/opentracks/settings/PreferencesUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/settings/PreferencesUtils.java
@@ -439,7 +439,14 @@ public class PreferencesUtils {
     public static void setVoiceAnnounceAverageHeartRate(boolean value) {
         setBoolean(R.string.voice_announce_average_heart_rate_key, value);
     }
-
+    public static boolean shouldVoiceAnnounceMaxSlope() {
+        return getBoolean(R.string.voice_announce_max_slope_key, true);
+    }
+    
+    @VisibleForTesting
+    public static void setVoiceAnnounceMaxSlope(boolean value) {
+        setBoolean(R.string.voice_announce_max_slope_key, value);
+    }
     // recoding related setting helper methods
     public static boolean shouldVoiceAnnounceMaxSpeedRecording() {
         return getBoolean(R.string.voice_announce_max_speed_recording_key, true);

--- a/src/main/java/de/dennisguse/opentracks/settings/PreferencesUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/settings/PreferencesUtils.java
@@ -490,11 +490,11 @@ public class PreferencesUtils {
     }
     //recording related data for average slope's helper methods for each run
     public static boolean shouldVoiceAnnounceAverageslopeRun() {
-        return getBoolean(R.string.voice_announce_average_slope_recording_key, true);
+        return getBoolean(R.string.voice_announce_average_slope_run_key, true);
     }
     @VisibleForTesting
     public static void setVoiceAnnounceAverageslopeRun(boolean value) {
-        setBoolean(R.string.voice_announce_average_slope_recording_key, value);
+        setBoolean(R.string.voice_announce_average_slope_run_key, value);
 
     }
 

--- a/src/main/java/de/dennisguse/opentracks/settings/PreferencesUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/settings/PreferencesUtils.java
@@ -440,6 +440,16 @@ public class PreferencesUtils {
         setBoolean(R.string.voice_announce_average_heart_rate_key, value);
     }
 
+    // recoding related setting helper methods
+    public static boolean shouldVoiceAnnounceMaxSpeedRecording() {
+        return getBoolean(R.string.voice_announce_max_speed_recording_key, true);
+    }
+
+    @VisibleForTesting
+    public static void setVoiceAnnounceMaxSpeedRecording(boolean value) {
+        setBoolean(R.string.voice_announce_max_speed_recording_key, value);
+    }
+
     public static Distance getRecordingDistanceInterval() {
         return Distance.of(getInt(R.string.recording_distance_interval_key, getRecordingDistanceIntervalDefaultInternal()));
     }

--- a/src/main/java/de/dennisguse/opentracks/settings/PreferencesUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/settings/PreferencesUtils.java
@@ -460,10 +460,6 @@ public class PreferencesUtils {
         setBoolean(R.string.voice_announce_time_skied_recording_key, value);
     }
 
-    @VisibleForTesting
-    public static void setVoiceAnnounceTimeSkiedRecording(boolean value) {
-        setBoolean(R.string.voice_announce_time_skied_recording_key, value);
-    }
 
     public static Distance getRecordingDistanceInterval() {
         return Distance.of(getInt(R.string.recording_distance_interval_key, getRecordingDistanceIntervalDefaultInternal()));

--- a/src/main/java/de/dennisguse/opentracks/settings/PreferencesUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/settings/PreferencesUtils.java
@@ -470,6 +470,14 @@ public class PreferencesUtils {
         setBoolean(R.string.voice_announce_max_speed_recording_key, value);
     }
 
+    public static boolean shouldVoiceAnnounceAverageSpeedRecording() {
+        return getBoolean(R.string.voice_announce_average_speed_recording_key, true);
+    }
+    @VisibleForTesting
+    public static void setVoiceAnnounceAverageSpeedRecording(boolean value) {
+        setBoolean(R.string.voice_announce_average_speed_recording_key, value);
+    }
+
     public static Distance getRecordingDistanceInterval() {
         return Distance.of(getInt(R.string.recording_distance_interval_key, getRecordingDistanceIntervalDefaultInternal()));
     }

--- a/src/main/java/de/dennisguse/opentracks/settings/PreferencesUtils.java
+++ b/src/main/java/de/dennisguse/opentracks/settings/PreferencesUtils.java
@@ -456,6 +456,14 @@ public class PreferencesUtils {
     public static void setVoiceAnnounceMaxSpeedRecording(boolean value) {
         setBoolean(R.string.voice_announce_max_speed_recording_key, value);
     }
+    //recording related data for average slope's helper methods
+    public static boolean shouldVoiceAnnounceAveragesloperecording() {
+        return getBoolean(R.string.voice_announce_average_slope_recording_key, true);
+    }
+    @VisibleForTesting
+    public static void setVoiceAnnounceAveragesloperecording(boolean value) {
+        setBoolean(R.string.voice_announce_average_slope_recording_key, value);
+    }
 
     public static Distance getRecordingDistanceInterval() {
         return Distance.of(getInt(R.string.recording_distance_interval_key, getRecordingDistanceIntervalDefaultInternal()));

--- a/src/main/res/values/settings.xml
+++ b/src/main/res/values/settings.xml
@@ -256,6 +256,9 @@
     <string name="voice_announce_lap_heart_rate_key" translatable="false">voiceAnnounceLapHeartRate</string>
     <bool name="voice_announce_lap_heart_rate_default" translatable="false">false</bool>
 
+    <string name="voice_announce_run_average_speed_key" translatable="false">voiceAnnounceRunAverageSpeed</string>
+    <bool name="voice_announce_run_average_speed_default" translatable="false">false</bool>
+
     <string name="export_trackfileformat_key" translatable="false">exportTrackFileFormat</string>
     <!-- See TrackFileFormat -->
     <string name="export_trackfileformat_default" translatable="false">KMZ_WITH_TRACKDETAIL_AND_SENSORDATA_AND_PICTURES</string>

--- a/src/main/res/values/settings.xml
+++ b/src/main/res/values/settings.xml
@@ -267,6 +267,8 @@
     <string name="voice_announce_average_slope_recording_key">voiceAnnounceAverageSlopeRecording</string>
     <bool name="voice_announce_average_slope_recording_default" translatable="false">true</bool>
 
+    <string name="voice_announce_average_slope_run_key">voiceAnnounceAverageSlopeRun</string>
+    <bool name="voice_announce_average_slope_run_default" translatable="false">true</bool>
   
   
   

--- a/src/main/res/values/settings.xml
+++ b/src/main/res/values/settings.xml
@@ -262,23 +262,24 @@
 
     <string name="voice_announce_max_speed_recording_key">voiceAnnounceMaxSpeedRecording</string>
     <bool name="voice_announce_max_speed_recording_default" translatable="false">true</bool>
-    <string name="voice_announce_average_slope_recording_key">voiceAnnounceAverageSlopeRecording</string>
 
+    <string name="voice_announce_average_slope_recording_key">voiceAnnounceAverageSlopeRecording</string>
     <bool name="voice_announce_average_slope_recording_default" translatable="false">true</bool>
-    <string name="export_trackfileformat_key" translatable="false">exportTrackFileFormat</string>
+
   
   
   
     <!-- Run related data -->
+
     <string name="voice_announce_run_average_speed_key" translatable="false">voiceAnnounceRunAverageSpeed</string>
     <bool name="voice_announce_run_average_speed_default" translatable="false">false</bool>
 
 
-    <string name="voice_announce_max_slope_key">voiceAnnounceMaxSlope</string>
-    <bool name="voice_announce_max_slope_default" translatable="false">true</bool>
+
   
   
     <!-- See TrackFileFormat -->
+    <string name="export_trackfileformat_key" translatable="false">exportTrackFileFormat</string>
     <string name="export_trackfileformat_default" translatable="false">KMZ_WITH_TRACKDETAIL_AND_SENSORDATA_AND_PICTURES</string>
 
     <string name="import_prevent_reimport_key" translatable="false">preventReimportTrackKey</string>

--- a/src/main/res/values/settings.xml
+++ b/src/main/res/values/settings.xml
@@ -255,7 +255,8 @@
     <bool name="voice_announce_average_heart_rate_default" translatable="false">false</bool>
     <string name="voice_announce_lap_heart_rate_key" translatable="false">voiceAnnounceLapHeartRate</string>
     <bool name="voice_announce_lap_heart_rate_default" translatable="false">false</bool>
-
+    <string name="voice_announce_max_slope_key">voiceAnnounceMaxSlope</string>
+    <bool name="voice_announce_max_slope_default" translatable="false">true</bool>
     <!-- Recording related data -->
     <string name="voice_announce_max_speed_recording_key">voiceAnnounceMaxSpeedRecording</string>
     <bool name="voice_announce_max_speed_recording_default" translatable="false">true</bool>

--- a/src/main/res/values/settings.xml
+++ b/src/main/res/values/settings.xml
@@ -259,6 +259,10 @@
     <!-- Recording related data -->
     <string name="voice_announce_max_speed_recording_key">voiceAnnounceMaxSpeedRecording</string>
     <bool name="voice_announce_max_speed_recording_default" translatable="false">true</bool>
+	
+	<!-- Recording related data -->
+    <string name="voice_announce_time_skied_recording_key">voiceAnnounceTimeSkiedRecording</string>
+    <bool name="voice_announce_time_skied_recording_default" translatable="false">true</bool>
 
     <string name="export_trackfileformat_key" translatable="false">exportTrackFileFormat</string>
     <!-- See TrackFileFormat -->

--- a/src/main/res/values/settings.xml
+++ b/src/main/res/values/settings.xml
@@ -256,6 +256,10 @@
     <string name="voice_announce_lap_heart_rate_key" translatable="false">voiceAnnounceLapHeartRate</string>
     <bool name="voice_announce_lap_heart_rate_default" translatable="false">false</bool>
 
+    <!-- Recording related data -->
+    <string name="voice_announce_max_speed_recording_key">voiceAnnounceMaxSpeedRecording</string>
+    <bool name="voice_announce_max_speed_recording_default" translatable="false">true</bool>
+
     <string name="export_trackfileformat_key" translatable="false">exportTrackFileFormat</string>
     <!-- See TrackFileFormat -->
     <string name="export_trackfileformat_default" translatable="false">KMZ_WITH_TRACKDETAIL_AND_SENSORDATA_AND_PICTURES</string>

--- a/src/main/res/values/settings.xml
+++ b/src/main/res/values/settings.xml
@@ -255,12 +255,14 @@
     <bool name="voice_announce_average_heart_rate_default" translatable="false">false</bool>
     <string name="voice_announce_lap_heart_rate_key" translatable="false">voiceAnnounceLapHeartRate</string>
     <bool name="voice_announce_lap_heart_rate_default" translatable="false">false</bool>
+    <!-- Recording related data -->
     <string name="voice_announce_max_slope_key">voiceAnnounceMaxSlope</string>
     <bool name="voice_announce_max_slope_default" translatable="false">true</bool>
-    <!-- Recording related data -->
     <string name="voice_announce_max_speed_recording_key">voiceAnnounceMaxSpeedRecording</string>
     <bool name="voice_announce_max_speed_recording_default" translatable="false">true</bool>
+    <string name="voice_announce_average_slope_recording_key">voiceAnnounceAverageSlopeRecording</string>
 
+    <bool name="voice_announce_average_slope_recording_default" translatable="false">true</bool>
     <string name="export_trackfileformat_key" translatable="false">exportTrackFileFormat</string>
     <!-- See TrackFileFormat -->
     <string name="export_trackfileformat_default" translatable="false">KMZ_WITH_TRACKDETAIL_AND_SENSORDATA_AND_PICTURES</string>

--- a/src/main/res/values/settings.xml
+++ b/src/main/res/values/settings.xml
@@ -256,6 +256,9 @@
     <string name="voice_announce_lap_heart_rate_key" translatable="false">voiceAnnounceLapHeartRate</string>
     <bool name="voice_announce_lap_heart_rate_default" translatable="false">false</bool>
 
+    <string name="voice_announce_max_speed_run_key">voiceAnnounceMaxSpeedRun</string>
+    <bool name="voice_announce_max_speed_run_default" translatable="false">true</bool>
+
     <string name="export_trackfileformat_key" translatable="false">exportTrackFileFormat</string>
     <!-- See TrackFileFormat -->
     <string name="export_trackfileformat_default" translatable="false">KMZ_WITH_TRACKDETAIL_AND_SENSORDATA_AND_PICTURES</string>

--- a/src/main/res/values/settings.xml
+++ b/src/main/res/values/settings.xml
@@ -268,6 +268,9 @@
     <string name="voice_announce_max_speed_recording_key">voiceAnnounceMaxSpeedRecording</string>
     <bool name="voice_announce_max_speed_recording_default" translatable="false">true</bool>
 
+    <string name="voice_announce_average_speed_recording_key">voiceAnnounceAverageSlopeRecording</string>
+    <bool name="voice_announce_average_speed_recording_default" translatable="false">true</bool>
+
     <string name="export_trackfileformat_key" translatable="false">exportTrackFileFormat</string>
     <!-- See TrackFileFormat -->
     <string name="export_trackfileformat_default" translatable="false">KMZ_WITH_TRACKDETAIL_AND_SENSORDATA_AND_PICTURES</string>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -413,6 +413,7 @@ limitations under the License.
     <string name="settings_announcements_lap_heart_rate">Lap heart rate</string>
     <string name="settings_announcements_average_speed_pace">Average speed/pace</string>
     <string name="settings_announcements_lap_speed_pace">Lap speed/pace</string>
+    <string name="settings_announcements_max_slope">Max slope</string>
 
     <!-- Recording Related Data -->
     <string name="settings_announcements_max_speed_recording">Max speed/recording</string>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -419,6 +419,7 @@ limitations under the License.
 
     <!-- Recording Related Data -->
     <string name="settings_announcements_max_speed_recording">Max speed/recording</string>
+    <string name="settings_announcements_average_speed_recording">Average speed/recording</string>
 
     <!-- Custom Layout -->
 

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -360,6 +360,8 @@ limitations under the License.
     <string name="settings_announcements_statistics_title">Statistics Announcements</string>
     <string name="settings_announcements_summary">Time, Distance, Voice Speed</string>
 
+    <string name="settings_announcements_recording_title">Announcements After Recording</string>
+
     <string name="settings_import_export_title">Import/Export</string>
     <string name="settings_import_export_summary">Import, Export, Auto Export</string>
 
@@ -411,6 +413,9 @@ limitations under the License.
     <string name="settings_announcements_lap_heart_rate">Lap heart rate</string>
     <string name="settings_announcements_average_speed_pace">Average speed/pace</string>
     <string name="settings_announcements_lap_speed_pace">Lap speed/pace</string>
+
+    <!-- Recording Related Data -->
+    <string name="settings_announcements_max_speed_recording">Max speed/recording</string>
 
     <!-- Custom Layout -->
 

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -417,8 +417,9 @@ limitations under the License.
 
     <!-- Recording Related Data -->
     <string name="settings_announcements_max_speed_recording">Max speed/recording</string>
+    <!-- Recording Related Data -->
+    <string name="settings_announcements_average_slope_recording">Average slope</string>
 
-    <!-- Custom Layout -->
 
 
     <string name="custom_layout_list_title">Layouts</string>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -416,7 +416,7 @@ limitations under the License.
 
     <!-- Recording Related Data -->
     <string name="settings_announcements_max_speed_recording">Max speed/recording</string>
-
+	<string name="settings_announcements_time_skied_recording">Time skied/recording</string>
     <!-- Custom Layout -->
 
 

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -423,7 +423,7 @@ limitations under the License.
     <string name="settings_announcements_max_speed_recording">Max speed/recording</string>
     <string name="settings_announcements_max_slope">Max slope</string>
     <string name="settings_announcements_average_slope_recording">Average slope</string>
-
+    <string name="settings_announcements_average_slope_run">Average slope</string>
 
 
 

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -411,6 +411,7 @@ limitations under the License.
     <string name="settings_announcements_lap_heart_rate">Lap heart rate</string>
     <string name="settings_announcements_average_speed_pace">Average speed/pace</string>
     <string name="settings_announcements_lap_speed_pace">Lap speed/pace</string>
+    <string name="settings_announcements_run_average_speed">Run Average Speed</string>
 
     <!-- Custom Layout -->
 

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -411,6 +411,7 @@ limitations under the License.
     <string name="settings_announcements_lap_heart_rate">Lap heart rate</string>
     <string name="settings_announcements_average_speed_pace">Average speed/pace</string>
     <string name="settings_announcements_lap_speed_pace">Lap speed/pace</string>
+    <string name="settings_announcements_max_speed_run">Max speed/run</string>
 
     <!-- Custom Layout -->
 
@@ -709,4 +710,6 @@ limitations under the License.
     <string name="always">Always</string>
 
     <string name="introduction_osm_dashboard">OpenTracks itself does not provide a map. Please install OSMDashboard to view your recordings on a map.</string>
+
+
 </resources>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -361,6 +361,7 @@ limitations under the License.
     <string name="settings_announcements_summary">Time, Distance, Voice Speed</string>
 
     <string name="settings_announcements_recording_title">Announcements After Recording</string>
+    <string name="settings_announcements_run_title">Announcements After Run</string>
 
     <string name="settings_import_export_title">Import/Export</string>
     <string name="settings_import_export_summary">Import, Export, Auto Export</string>

--- a/src/main/res/xml/settings_announcements.xml
+++ b/src/main/res/xml/settings_announcements.xml
@@ -68,10 +68,7 @@
             android:defaultValue="@bool/voice_announce_lap_heart_rate_default"
             android:key="@string/voice_announce_lap_heart_rate_key"
             android:title="@string/settings_announcements_lap_heart_rate" />
-        <SwitchPreferenceCompat
-            android:defaultValue="@bool/voice_announce_max_speed_run_default"
-            android:key="@string/voice_announce_max_speed_run_key"
-            android:title="@string/settings_announcements_max_speed_run" />
+
     </PreferenceCategory>
 
     <PreferenceCategory android:title="@string/settings_announcements_recording_title">
@@ -98,5 +95,9 @@
             android:defaultValue="@bool/voice_announce_run_average_speed_default"
             android:key="@string/voice_announce_run_average_speed_key"
             android:title="@string/settings_announcements_run_average_speed" />
+        <SwitchPreferenceCompat
+            android:defaultValue="@bool/voice_announce_max_speed_run_default"
+            android:key="@string/voice_announce_max_speed_run_key"
+            android:title="@string/settings_announcements_max_speed_run" />
     </PreferenceCategory>
 </PreferenceScreen>

--- a/src/main/res/xml/settings_announcements.xml
+++ b/src/main/res/xml/settings_announcements.xml
@@ -68,11 +68,6 @@
             android:defaultValue="@bool/voice_announce_lap_heart_rate_default"
             android:key="@string/voice_announce_lap_heart_rate_key"
             android:title="@string/settings_announcements_lap_heart_rate" />
-
-        <SwitchPreferenceCompat
-            android:defaultValue="@bool/voice_announce_run_avg_speed_default"
-            android:key="@string/voice_announce_run_average_speed_key"
-            android:title="@string/settings_announcements_run_average_speed" />
     </PreferenceCategory>
 
     <PreferenceCategory android:title="@string/settings_announcements_recording_title">
@@ -80,5 +75,12 @@
             android:defaultValue="@bool/voice_announce_max_speed_recording_default"
             android:key="@string/voice_announce_max_speed_recording_key"
             android:title="@string/settings_announcements_max_speed_recording" />
+    </PreferenceCategory>
+
+    <PreferenceCategory android:title="@string/settings_announcements_run_title">
+        <SwitchPreferenceCompat
+            android:defaultValue="@bool/voice_announce_run_average_speed_default"
+            android:key="@string/voice_announce_run_average_speed_key"
+            android:title="@string/settings_announcements_run_average_speed" />
     </PreferenceCategory>
 </PreferenceScreen>

--- a/src/main/res/xml/settings_announcements.xml
+++ b/src/main/res/xml/settings_announcements.xml
@@ -69,7 +69,7 @@
             android:key="@string/voice_announce_lap_heart_rate_key"
             android:title="@string/settings_announcements_lap_heart_rate" />
         <SwitchPreferenceCompat
-            android:defaultValue="@bool/voice_announce_average_speed_pace_default"
+            android:defaultValue="@bool/voice_announce_max_speed_run_default"
             android:key="@string/voice_announce_max_speed_run_key"
             android:title="@string/settings_announcements_max_speed_run" />
     </PreferenceCategory>

--- a/src/main/res/xml/settings_announcements.xml
+++ b/src/main/res/xml/settings_announcements.xml
@@ -75,5 +75,10 @@
             android:defaultValue="@bool/voice_announce_max_speed_recording_default"
             android:key="@string/voice_announce_max_speed_recording_key"
             android:title="@string/settings_announcements_max_speed_recording" />
+			
+		<SwitchPreferenceCompat
+            android:defaultValue="@bool/voice_announce_time_skied_recording_default"
+            android:key="@string/voice_announce_time_skied_recording_key"
+            android:title="@string/settings_announcements_time_skied_recording" />
     </PreferenceCategory>
 </PreferenceScreen>

--- a/src/main/res/xml/settings_announcements.xml
+++ b/src/main/res/xml/settings_announcements.xml
@@ -80,5 +80,12 @@
             android:defaultValue="@bool/voice_announce_max_slope_default"
             android:key="@string/voice_announce_max_slope_key"
             android:title="@string/settings_announcements_max_slope" />
+        <SwitchPreference
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:defaultValue="@bool/voice_announce_max_slope_default"
+            android:title="@string/settings_announcements_average_slope_recording"
+            app:key="@string/voice_announce_average_slope_recording_key" />
+
     </PreferenceCategory>
 </PreferenceScreen>

--- a/src/main/res/xml/settings_announcements.xml
+++ b/src/main/res/xml/settings_announcements.xml
@@ -95,6 +95,12 @@
             android:defaultValue="@bool/voice_announce_run_average_speed_default"
             android:key="@string/voice_announce_run_average_speed_key"
             android:title="@string/settings_announcements_run_average_speed" />
+        <SwitchPreference
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:defaultValue="@bool/voice_announce_average_slope_run_default"
+            android:title="@string/settings_announcements_average_slope_run"
+            app:key="@string/voice_announce_average_slope_run_key" />
         <SwitchPreferenceCompat
             android:defaultValue="@bool/voice_announce_max_speed_run_default"
             android:key="@string/voice_announce_max_speed_run_key"

--- a/src/main/res/xml/settings_announcements.xml
+++ b/src/main/res/xml/settings_announcements.xml
@@ -78,13 +78,13 @@
             android:title="@string/settings_announcements_max_speed_recording" />
 
 			
-		    <SwitchPreferenceCompat
+        <SwitchPreferenceCompat
             android:defaultValue="@bool/voice_announce_time_skied_recording_default"
             android:key="@string/voice_announce_time_skied_recording_key"
             android:title="@string/settings_announcements_time_skied_recording" />
 
 
-        <SwitchPreference
+        <SwitchPreferenceCompat
             android:defaultValue="@bool/voice_announce_max_speed_recording_default"
             android:title="@string/settings_announcements_average_speed_recording"
             app:key="@string/voice_announce_average_speed_recording_key" />
@@ -93,9 +93,8 @@
             android:defaultValue="@bool/voice_announce_max_slope_default"
             android:key="@string/voice_announce_max_slope_key"
             android:title="@string/settings_announcements_max_slope" />
-        <SwitchPreference
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
+
+        <SwitchPreferenceCompat
             android:defaultValue="@bool/voice_announce_max_slope_default"
             android:title="@string/settings_announcements_average_slope_recording"
             app:key="@string/voice_announce_average_slope_recording_key" />
@@ -107,9 +106,7 @@
             android:defaultValue="@bool/voice_announce_run_average_speed_default"
             android:key="@string/voice_announce_run_average_speed_key"
             android:title="@string/settings_announcements_run_average_speed" />
-        <SwitchPreference
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
+        <SwitchPreferenceCompat
             android:defaultValue="@bool/voice_announce_average_slope_run_default"
             android:title="@string/settings_announcements_average_slope_run"
             app:key="@string/voice_announce_average_slope_run_key" />

--- a/src/main/res/xml/settings_announcements.xml
+++ b/src/main/res/xml/settings_announcements.xml
@@ -75,5 +75,10 @@
             android:defaultValue="@bool/voice_announce_max_speed_recording_default"
             android:key="@string/voice_announce_max_speed_recording_key"
             android:title="@string/settings_announcements_max_speed_recording" />
+
+        <SwitchPreferenceCompat
+            android:defaultValue="@bool/voice_announce_max_slope_default"
+            android:key="@string/voice_announce_max_slope_key"
+            android:title="@string/settings_announcements_max_slope" />
     </PreferenceCategory>
 </PreferenceScreen>

--- a/src/main/res/xml/settings_announcements.xml
+++ b/src/main/res/xml/settings_announcements.xml
@@ -76,6 +76,11 @@
             android:key="@string/voice_announce_max_speed_recording_key"
             android:title="@string/settings_announcements_max_speed_recording" />
 
+        <SwitchPreference
+            android:defaultValue="@bool/voice_announce_max_speed_recording_default"
+            android:title="@string/settings_announcements_average_speed_recording"
+            app:key="@string/voice_announce_average_speed_recording_key" />
+
         <SwitchPreferenceCompat
             android:defaultValue="@bool/voice_announce_max_slope_default"
             android:key="@string/voice_announce_max_slope_key"

--- a/src/main/res/xml/settings_announcements.xml
+++ b/src/main/res/xml/settings_announcements.xml
@@ -68,6 +68,10 @@
             android:defaultValue="@bool/voice_announce_lap_heart_rate_default"
             android:key="@string/voice_announce_lap_heart_rate_key"
             android:title="@string/settings_announcements_lap_heart_rate" />
+        <SwitchPreferenceCompat
+            android:defaultValue="@bool/voice_announce_average_speed_pace_default"
+            android:key="@string/voice_announce_max_speed_run_key"
+            android:title="@string/settings_announcements_max_speed_run" />
     </PreferenceCategory>
 
 </PreferenceScreen>

--- a/src/main/res/xml/settings_announcements.xml
+++ b/src/main/res/xml/settings_announcements.xml
@@ -70,4 +70,10 @@
             android:title="@string/settings_announcements_lap_heart_rate" />
     </PreferenceCategory>
 
+    <PreferenceCategory android:title="@string/settings_announcements_recording_title">
+        <SwitchPreferenceCompat
+            android:defaultValue="@bool/voice_announce_max_speed_recording_default"
+            android:key="@string/voice_announce_max_speed_recording_key"
+            android:title="@string/settings_announcements_max_speed_recording" />
+    </PreferenceCategory>
 </PreferenceScreen>

--- a/src/main/res/xml/settings_announcements.xml
+++ b/src/main/res/xml/settings_announcements.xml
@@ -68,6 +68,11 @@
             android:defaultValue="@bool/voice_announce_lap_heart_rate_default"
             android:key="@string/voice_announce_lap_heart_rate_key"
             android:title="@string/settings_announcements_lap_heart_rate" />
+
+        <SwitchPreferenceCompat
+            android:defaultValue="@bool/voice_announce_run_avg_speed_default"
+            android:key="@string/voice_announce_run_average_speed_key"
+            android:title="@string/settings_announcements_run_average_speed" />
     </PreferenceCategory>
 
 </PreferenceScreen>


### PR DESCRIPTION
**Describe the pull request**
This pull request introduces the feature to announce the maximum slope at the end of each recording. Previously, the maximum slope was not announced. With this enhancement, users will now receive voice announcements regarding the maximum slope based on elevation data at the conclusion of their recordings. However, the implementation is not yet fully completed as it requires collecting data from other groups.

**Link to the the issue**
#97 



