### PR TITLE
GH-135 : Added a method to calculate the average speed

### DIFF
--- a/src/main/java/de/dennisguse/opentracks/data/models/TrackSegment.java
+++ b/src/main/java/de/dennisguse/opentracks/data/models/TrackSegment.java
@@ -145,4 +145,23 @@ public class TrackSegment {
 
         return Distance.of(averageDistance);
     }
+
+    /**
+     * Calculates the average speed
+     * @return The average speed in meters per second (m/s).
+     *         Returns NaN if the total time is zero (indicating division by zero).
+     */
+    public double getAverageSpeed() {
+        Distance distance = getDistance();
+        Duration totalTime = getTotalTime();
+
+        if (distance == null || totalTime == null || totalTime.isZero()) {
+            return Double.NaN;
+        }
+
+        double totalDistance = distance.toM();
+        long totalTimeSeconds = totalTime.getSeconds();
+        return totalDistance / totalTimeSeconds;
+    }
+
 }


### PR DESCRIPTION
Adding new feature called getAverageSpeed which is designed to compute the average speed using the data available.This method encapsulates the logic for computing the average speed based on available data, ensuring robustness by handling edge cases and providing a clear and concise interface for obtaining this metric within the context of the class.

Link to the the issue
#135 